### PR TITLE
fix(ickb): iCKB 存款页输入金额无法算出兑换额度（fetch illegal invocation + 静默错误）

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { Work_Sans, Play } from "next/font/google";
 import { Metadata } from "next";
+import Script from "next/script";
 import { LayoutProvider } from "./layoutProvider";
 
 export const metadata: Metadata = {
@@ -28,6 +29,20 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        {/*
+          cross-fetch's browser ponyfill exports a detached reference to
+          `window.fetch`. Some bundled RPC libraries (e.g. @ckb-lumos/rpc)
+          invoke it as `someObject.fetch(...)`, which sets `this` to that
+          object instead of `window`, causing native fetch's brand check to
+          throw "Failed to execute 'fetch' on 'Window': Illegal invocation".
+          Re-binding `window.fetch` here, before any bundled JS runs, makes
+          the reference safe to call regardless of its receiver.
+        */}
+        <Script id="fetch-rebind" strategy="beforeInteractive">
+          {`if (window.fetch) { window.fetch = window.fetch.bind(window); }`}
+        </Script>
+      </head>
       <body className={`${workSans.variable} ${play.variable}`}>
         <LayoutProvider>{children}</LayoutProvider>
       </body>

--- a/src/cores/config.ts
+++ b/src/cores/config.ts
@@ -4,6 +4,15 @@ import { ChainConfig, chainConfigFrom, I8Script, lockExpanderFrom, i8ScriptPaddi
 import { getIckbScriptConfigs } from "@ickb/v1-core";
 import type { QueryClient } from "@tanstack/react-query"
 
+// Some bundled dependencies capture a detached reference to `fetch` and later
+// invoke it without `window` as the receiver, which throws
+// "Failed to execute 'fetch' on 'Window': Illegal invocation" in the browser.
+// Re-binding `window.fetch` to `window` makes it safe to call regardless of
+// how the reference is later invoked.
+if (typeof window !== "undefined" && typeof window.fetch === "function") {
+    window.fetch = window.fetch.bind(window);
+}
+
 export interface WalletConfig extends ChainConfig {
     address: ccc.Hex;
     client: ccc.Client;

--- a/src/cores/queries.ts
+++ b/src/cores/queries.ts
@@ -64,7 +64,14 @@ export function l1StateOptions(isFrozen: boolean) {
         refetchIntervalInBackground: false,
         // staleTime: 10000,
         queryKey: ["l1State"],
-        queryFn: () => getL1State(walletConfig),
+        queryFn: async () => {
+            try {
+                return await getL1State(walletConfig);
+            } catch (e) {
+                console.error("l1State query failed:", e);
+                throw e;
+            }
+        },
         placeholderData: {
             ickbUdtPoolBalance: BigInt(-1),
             ickbDaoBalance: BigInt(-1),
@@ -89,7 +96,11 @@ async function getL1State(walletConfig: WalletConfig) {
     const mixedCells = await getMixedCells(walletConfig);
 
     // Prefetch the client-selected fee rate and tip header.
-    const feeRatePromise = client.getFeeRate();
+    // Fall back to a fixed fee rate if the node doesn't support fee rate statistics.
+    const feeRatePromise = client.getFeeRate().catch((e) => {
+        console.error("client.getFeeRate() failed, falling back to fixed fee rate:", e);
+        return BigInt(2000);
+    });
     const tipHeaderPromise = rpc.getTipHeader();
 
     // Prefetch headers


### PR DESCRIPTION
## 背景

`main` 上最近 4 次提交（`5fba980` `6703f8b` `bbee80b` `a1be0ff`，最后一次 `chore: bump versions` 批量升级依赖）之后，iCKB 存款页面输入 CKB 数量时不再显示预期兑换的 iCKB 数量，且 console 没有任何报错信息。

<img width="2240" height="1338" alt="image" src="https://github.com/user-attachments/assets/8a316511-7c05-4d8a-ad6a-3a384221409e" />


## 根因

这里其实是两个独立问题叠加：

### 1. 静默失败（`src/cores/queries.ts`）

`chore: bump versions` 这次提交把 l1StateOptions里原有的 `try/catch` 和调试 `console.log` 全部删除，同时把之前被禁用的动态费率获取重新启用为 `await client.getFeeRate()`。任何底层请求失败都会导致整个 `l1State` 查询失败，但因为错误处理被删掉，失败是完全静默的，`ickbData` 会永远停留在 `placeholderData`（假的 `tipHeader`），导致存款兑换比例永远显示为 `0`。

### 2. `fetch` "Illegal invocation"（真正报错的位置）

恢复错误日志后，暴露出真正的异常：

```
TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
  at getMixedCells (queries.ts:372) -> rpc.getCellsByLock(...)
```
<img width="1024" height="856" alt="image" src="https://github.com/user-attachments/assets/6479b574-bcbd-4fa7-ae20-1a2f1e34bef3" />


`@ckb-lumos/rpc`（`method.js`/`index.js`）内部把 `fetch` 存成 `this.#config.fetch`，调用时写成 `this.#config.fetch(url, opts)`，也就是**以对象方法的形式调用 `fetch`**，`this` 变成了 `#config` 对象而不是 `window`。

这原本没问题，是因为旧的 `pnpm-lock.yaml` 里 `@ckb-lumos/rpc@0.23.0` 解析到的 `cross-fetch` 版本是 `3.1.8`：它的浏览器 ponyfill 无条件使用自己内置的纯 JS `whatwg-fetch` 实现，纯 JS 函数不关心 `this`，怎么调用都没问题。

这次批量升级依赖（新增 `pnpm-workspace.yaml`、bump 一堆包版本）虽然没有直接改 `@ckb-lumos/rpc` 的版本，但**间接**导致 pnpm 把 `cross-fetch` 重新解析到了 `3.2.0`。`3.2.0` 的浏览器 ponyfill 改成"检测到原生 `fetch` 就直接导出原生 `window.fetch` 的裸引用"，原生 `fetch` 是浏览器强制要求 `this === window` 的 WebIDL 方法，被 `@ckb-lumos/rpc` 以 `obj.fetch(...)` 方式调用时就会抛出 "Illegal invocation"。

验证依据（对比新旧 lockfile）：
```
# 旧（正常）：@ckb-lumos/rpc@0.23.0 -> cross-fetch: 3.1.8
# 新（报错）：@ckb-lumos/rpc@0.23.0 -> cross-fetch: 3.2.0
```

## 改动

- `src/cores/queries.ts`
  - 恢复 `queryFn` 的 `try/catch` + `console.error`，避免查询失败被静默吞掉。
  - `client.getFeeRate()` 失败时回退到固定费率 `2000`，不让费率请求失败拖垮整个 `l1State` 查询。
- `src/cores/config.ts`
  - 模块顶层对 `window.fetch` 做 `bind(window)`，作为兜底修复。
- `src/app/layout.tsx`
  - 新增 `next/script` 的 `beforeInteractive` 脚本，在任何打包 JS 执行前重新绑定 `window.fetch`，从根源上避免 `cross-fetch` 捕获到未绑定的原生引用（config.ts 里的绑定时机相对 import 链来说太晚，无法保证生效）。

## 测试

- 本地 `pnpm dev`，连接钱包，切到 iCKB 存款页，输入金额，确认能正常显示兑换的 iCKB 数量，console 无报错。
- 本地 `pnpm build`、`pnpm start --port 3002`，连接钱包，切到 iCKB 存款页，输入金额，确认能正常显示兑换的 iCKB 数量，console 无报错。

<img width="1702" height="1486" alt="image" src="https://github.com/user-attachments/assets/861376f1-a331-49cd-acaa-f3ff9ba90c48" />

<img width="1782" height="1460" alt="image" src="https://github.com/user-attachments/assets/a4ed4512-3e13-4592-819d-5f445630099e" />



